### PR TITLE
Handle unreachable hosts

### DIFF
--- a/src/TelescopeGuzzleRecorder.php
+++ b/src/TelescopeGuzzleRecorder.php
@@ -46,11 +46,9 @@ class TelescopeGuzzleRecorder
                 ['query_string' => $this->request->queryString()],
                 ['payload' => $this->payload($this->input($this->request))]
             ),
-            ...$this->response ? [
-                'response_status' => $this->response->status(),
-                'response_headers' => $this->headers($this->response->headers()),
-                'response' => $this->response($this->response),
-            ] : [],
+            'response_status' => $this->response ? $this->response->status() : null,
+            'response_headers' => $this->response ? $this->headers($this->response->headers()) : null,
+            'response' => $this->response ? $this->response($this->response) : null,
             'duration' => $this->duration(),
         ]);
 

--- a/src/TelescopeGuzzleRecorder.php
+++ b/src/TelescopeGuzzleRecorder.php
@@ -15,13 +15,15 @@ class TelescopeGuzzleRecorder
 
     private Request $request;
 
-    private Response $response;
+    private ?Response $response;
 
     public function __construct(TransferStats $transferStats)
     {
         $this->transferStats = $transferStats;
         $this->request = new Request($transferStats->getRequest());
-        $this->response = new Response($transferStats->getResponse());
+
+        $transferStatsResponse = $transferStats->getResponse();
+        $this->response = $transferStatsResponse ? new Response($transferStatsResponse) : null;
     }
 
     public static function recordGuzzleRequest(TransferStats $transferStats)
@@ -44,9 +46,11 @@ class TelescopeGuzzleRecorder
                 ['query_string' => $this->request->queryString()],
                 ['payload' => $this->payload($this->input($this->request))]
             ),
-            'response_status' => $this->response->status(),
-            'response_headers' => $this->headers($this->response->headers()),
-            'response' => $this->response($this->response),
+            ...$this->response ? [
+                'response_status' => $this->response->status(),
+                'response_headers' => $this->headers($this->response->headers()),
+                'response' => $this->response($this->response),
+            ] : [],
             'duration' => $this->duration(),
         ]);
 


### PR DESCRIPTION
# Description
-  This PR adds null safety to the `TelescopeGuzzleRecorder` so that it can handle unreachable host responses (null responses).

# Old Behaviour
- The watcher throws an error due to not being able to get the properties of a null response object
- ![image](https://github.com/huzaifaarain/telescope-guzzle-watcher/assets/40928240/86d5210c-d420-44fb-9968-0311eff25e69)

# New Behaviour
- Just like the Laravel HTTP watcher, this watcher will silently log the error without throwing an error by itself as a non-reachable host is a commonly expected error and should be handled by the application
- ![image](https://github.com/huzaifaarain/telescope-guzzle-watcher/assets/40928240/e76e1995-7a27-4606-b2b4-b0c8a5725ec1)
- ![image](https://github.com/huzaifaarain/telescope-guzzle-watcher/assets/40928240/6075ac7d-3e97-4029-bdd5-6108d72e0d6d)





