### PR TITLE
Fix: Correct Guzzle client binding in Service Container

### DIFF
--- a/src/Watchers/TelescopeGuzzleWatcher.php
+++ b/src/Watchers/TelescopeGuzzleWatcher.php
@@ -24,7 +24,8 @@ class TelescopeGuzzleWatcher extends Watcher
 
     private function buildClient(Application $app): Closure
     {
-        return static function ($app, array $config): Client {
+        return static function ($app, array $parameters): Client {
+            $config = $parameters['config'] ?? []
             if (Telescope::isRecording()) {
                 $onStatsClosure = $config['on_stats'] ?? null;
                 $config['on_stats'] = function (TransferStats $stats) use ($onStatsClosure) {

--- a/src/Watchers/TelescopeGuzzleWatcher.php
+++ b/src/Watchers/TelescopeGuzzleWatcher.php
@@ -25,7 +25,7 @@ class TelescopeGuzzleWatcher extends Watcher
     private function buildClient(Application $app): Closure
     {
         return static function ($app, array $parameters): Client {
-            $config = $parameters['config'] ?? []
+            $config = $parameters['config'] ?? [];
             if (Telescope::isRecording()) {
                 $onStatsClosure = $config['on_stats'] ?? null;
                 $config['on_stats'] = function (TransferStats $stats) use ($onStatsClosure) {


### PR DESCRIPTION
The `app()` helper’s second parameter is an array of constructor parameters, not a config array.
Currently, `TelescopeGuzzleWatcher.php` assumes the second parameter is passed directly as the Guzzle client config, which is incorrect.

The proper way to bind a `GuzzleHttp\Client` instance with custom configuration is:
```
 app(Client::class, ['config' =>[
            'base_uri'              => 'https://google.com/',
            RequestOptions::HEADERS => [
                'Content-Type' => 'application/json',
                'Accept'       => 'application/json',
            ],
            'allow_redirects'       => [
                'max'             => 10,
                'strict'          => true,
                'referer'         => true,
                'protocols'       => ['https'],
                'track_redirects' => true,
            ],
        ]]);
```
This ensures the configuration is passed correctly to the Client constructor.
